### PR TITLE
Support GHC 9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         stack_yaml:
           - stack-ghc-8.10.yaml
           - stack-ghc-9.0.yaml
+          # - stack-ghc-9.2.yaml
+          - stack-ghc-9.4.yaml
           - stack-persistent-2.13.yaml
           - stack-persistent-2.14.yaml
         include:
@@ -20,7 +22,7 @@ jobs:
             latest: true
 
     name: build_and_test (${{ matrix.stack_yaml }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.5.0.1
+
 * Add GHC 9.4 support
 
 # v0.5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add GHC 9.4 support
+
 # v0.5.0.0
 
 * Export `SqlQueryT` constructor ([#46](https://github.com/brandonchinn178/persistent-mtl/pull/46))

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: persistent-mtl
-version: 0.5.0.0
+version: 0.5.0.1
 maintainer: Brandon Chinn <brandonchinn178@gmail.com>
 synopsis: Monad transformer for the persistent API
 description: |

--- a/package.yaml
+++ b/package.yaml
@@ -19,20 +19,27 @@ github: brandonchinn178/persistent-mtl
 library:
   source-dirs: src
   dependencies:
-    - base >= 4.14 && < 4.16
+    - base >= 4.14 && < 5
     - conduit >= 1.3.4 && < 1.4
     - containers >= 0.6 && < 0.7
     - exceptions >= 0.10 && < 0.11
     - monad-logger >= 0.3 && < 0.4
     - mtl >= 2.2.2 && < 2.3
     - persistent >= 2.13 && < 2.15
-    - resource-pool >= 0.2.3.2 && < 0.3
+    - resource-pool >= 0.2.3.2 && < 0.4
     - resourcet >= 1.2.4 && < 1.3
-    - text >= 1.2.4 && < 1.3
+    - text >= 1.2.4 && < 2.1
     - transformers >= 0.5.6 && < 0.6
     - unliftio >= 0.2 && < 0.3
     - unliftio-core >= 0.2 && < 0.3
     - unliftio-pool >= 0.2 && < 0.3
+
+  when:
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/20836
+    - condition: >
+        impl(ghc >= 9.2.0) && impl(ghc < 9.3) ||
+        impl(ghc >= 9.4.0) && impl(ghc < 9.4.3)
+      buildable: false
 
 tests:
   persistent-mtl-test:

--- a/persistent-mtl.cabal
+++ b/persistent-mtl.cabal
@@ -44,21 +44,24 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.14 && <4.16
+      base >=4.14 && <5
     , conduit >=1.3.4 && <1.4
     , containers ==0.6.*
     , exceptions ==0.10.*
     , monad-logger ==0.3.*
     , mtl >=2.2.2 && <2.3
     , persistent >=2.13 && <2.15
-    , resource-pool >=0.2.3.2 && <0.3
+    , resource-pool >=0.2.3.2 && <0.4
     , resourcet >=1.2.4 && <1.3
-    , text >=1.2.4 && <1.3
+    , text >=1.2.4 && <2.1
     , transformers >=0.5.6 && <0.6
     , unliftio ==0.2.*
     , unliftio-core ==0.2.*
     , unliftio-pool ==0.2.*
   default-language: Haskell2010
+  if impl(ghc >= 9.2.0) && impl(ghc < 9.3) || impl(ghc >= 9.4.0) && impl(ghc < 9.4.3)
+
+    buildable: False
 
 test-suite persistent-mtl-test
   type: exitcode-stdio-1.0

--- a/persistent-mtl.cabal
+++ b/persistent-mtl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           persistent-mtl
-version:        0.5.0.0
+version:        0.5.0.1
 synopsis:       Monad transformer for the persistent API
 description:    A monad transformer and mtl-style type class for using the
                 persistent API directly in your monad transformer stack.

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.20
+resolver: lts-19.33
 
 extra-deps:
   - tasty-autocollect-0.3.0.0

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -1,0 +1,12 @@
+resolver: lts-20.0
+
+extra-deps:
+  # https://github.com/yesodweb/persistent/issues/1406#issuecomment-1226741099
+  - persistent-2.13.3.3
+
+flags:
+  explainable-predicates:
+    regex: false
+
+ghc-options:
+  "$locals": -Werror

--- a/stack-ghc-9.4.yaml
+++ b/stack-ghc-9.4.yaml
@@ -1,0 +1,11 @@
+resolver: nightly-2022-11-19
+
+extra-deps:
+  - tasty-autocollect-0.3.2.0
+
+flags:
+  explainable-predicates:
+    regex: false
+
+ghc-options:
+  "$locals": -Werror

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,20 +7,20 @@ packages:
 - completed:
     hackage: tasty-autocollect-0.3.0.0@sha256:9026c5a96bb871513a4213ae3c9105538f12bb5ad6400fe05a56c69e6fc85424,4734
     pantry-tree:
-      size: 3903
       sha256: e796c1754a91aec1953da308cf5d9751a6b2bd219666fb2fe89672a244d7ba13
+      size: 3903
   original:
     hackage: tasty-autocollect-0.3.0.0
 - completed:
     hackage: persistent-2.13.3.3@sha256:4161988646638cfeb9e5fbd6020c25bc32718d3916b200b3b7861bb236e674d4,6839
     pantry-tree:
-      size: 6052
       sha256: dedf843319b92d1f00b61ecdf1d99c550860fe01360a00dbd5c90313267b43c7
+      size: 6052
   original:
     hackage: persistent-2.13.3.3
 snapshots:
 - completed:
-    size: 619173
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/20.yaml
-    sha256: be747117bed6d462806c883352c3206325b23480825103f5c87884e97e52819a
-  original: lts-19.20
+    sha256: 6d1532d40621957a25bad5195bfca7938e8a06d923c91bc52aa0f3c41181f2d4
+    size: 619204
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/33.yaml
+  original: lts-19.33

--- a/test/Example.hs
+++ b/test/Example.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-missing-methods #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}


### PR DESCRIPTION
Add support for GHC 9.4. Still not supported on GHC 9.2 because of a GHC bug: https://gitlab.haskell.org/ghc/ghc/-/issues/20836.

When merged, update Cabal metadata on Hackage