### PR TITLE
Export SqlQueryT constructor

### DIFF
--- a/src/Database/Persist/Monad.hs
+++ b/src/Database/Persist/Monad.hs
@@ -56,7 +56,7 @@ module Database.Persist.Monad
   , withTransaction
 
   -- * SqlQueryT monad transformer
-  , SqlQueryT
+  , SqlQueryT(..)
   , mapSqlQueryT
   , runSqlQueryT
   , runSqlQueryTWith


### PR DESCRIPTION
This is a simple PR exporting the ``SqlQueryT`` constructor to enable the use of ``GeneralizedNewtypeDeriving``.